### PR TITLE
ScripID not accessed in function

### DIFF
--- a/nepse/stonk.py
+++ b/nepse/stonk.py
@@ -293,7 +293,6 @@ class NEPSE:
         return {'file':abspath}
 
     def saveCSV(self,scrip,start_date=None,end_date=None,filename=None):
-        scripID = [security for security in self.securities if security['symbol']==scrip.upper()][0]['securityId']
         resp = self.getChartHistory(scrip,start_date,end_date)
         if not filename:
             filename = f'{scrip.upper()}_{str(time.time())}.csv'


### PR DESCRIPTION
The `getChartHistory()` function takes the argument scrip and gives the response whereas `savecsv()` also has the scripID which isn't used so removing duplicate code could be better i believe